### PR TITLE
fix(consensus): correct retarget window interval and enforce difficulty ceiling at k=1024

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -186,23 +186,34 @@ maximum difficulty.
 
 At every height that is a multiple of 16 and greater than zero:
 
+### At height $h \ge 528$ (v2 retargeting):
+
 ```
-actual   = timestamp[h−1] − timestamp[h−17]
+anchor   = max(0, h − 17)
+actual   = timestamp[h−1] − timestamp[anchor]
 actual   = clamp(actual, TIMESPAN/4, TIMESPAN·4)
 target'  = target · actual / TIMESPAN
 target'  = clamp(target', POW_CEILING, POW_LIMIT)
 ```
 
-where `TIMESPAN = 16 · 600` seconds (2 h 40 m). At all other heights, `bits` must
-equal the previous block's `bits`.
+where `TIMESPAN = 16 · 600` seconds (2 h 40 m), `POW_CEILING = 0x1d03ffff` ($k = 1024$), and `POW_LIMIT = 0x1e100000` ($k = 1$).
 
-**Deviation.** Bitcoin reads the first block of the *previous* window rather
-than the block immediately preceding the window being closed — an off-by-one present
-since 2009 that makes each retarget cover 2015 intervals instead of 2016. ROFL uses
-the full 16-interval window (`timestamp[h−1] − timestamp[h−17]`). Additionally, ROFL
-enforces a maximum difficulty ceiling `POW_CEILING = 0x1d03ffff` matching `k = 1024`,
-preventing difficulty from running away into unbounded territory when blocks are mined
-faster than the puzzle ceiling.
+### At height $0 < h < 528$ (legacy retargeting):
+
+Historically, blocks prior to height 528 evaluated difficulty without a ceiling clamp using the starting index of the window:
+
+```
+actual   = timestamp[h−1] − timestamp[h−16]
+actual   = clamp(actual, TIMESPAN/4, TIMESPAN·4)
+target'  = target · actual / TIMESPAN
+target'  = min(target', POW_LIMIT)
+```
+
+At all other heights (where $h \pmod{16} \ne 0$), `bits` must equal the previous block's `bits`.
+
+**Deviations and historical context.**
+1. **Window anchoring:** In legacy blocks ($h < 528$), the window difference `timestamp[h−1] − timestamp[h−16]` covered 15 intervals instead of 16 (omitting the boundary block between retarget windows, reproducing Bitcoin's 2009 off-by-one). Starting at height 528 (`RETARGET_V2_HEIGHT`), ROFL anchors to `h − 17` (`max(0, h − 17)`), measuring all 16 consecutive block intervals without omission.
+2. **Difficulty ceiling:** Because puzzle capacity is capped at $K_{\max} = 1024$ (§5), difficulty above 1024 does not require additional puzzle solutions. Starting at height 528, `target'` is clamped to `POW_CEILING = 0x1d03ffff` to prevent runaway difficulty from trapping the chain in exponential scale during fast mining stretches.
 
 ## 7. Subsidy
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -39,6 +39,7 @@ do not exist.
 | Median time span | 11 blocks | 11 blocks |
 | Max future drift | 7200 s | 7200 s |
 | Proof-of-work limit | `0x1e100000` (k = 1) | `0x1d00ffff` |
+| Proof-of-work ceiling | `0x1d03ffff` (k = 1024) | — |
 | Genesis difficulty | `0x1e010000` (k = 15) | `0x1d00ffff` |
 | Work function | subset-sum, n = 40 | double SHA-256 |
 | Max puzzles per block | 1024 | — |
@@ -186,20 +187,22 @@ maximum difficulty.
 At every height that is a multiple of 16 and greater than zero:
 
 ```
-actual   = timestamp[h−1] − timestamp[h−16]
+actual   = timestamp[h−1] − timestamp[h−17]
 actual   = clamp(actual, TIMESPAN/4, TIMESPAN·4)
 target'  = target · actual / TIMESPAN
-target'  = min(target', POW_LIMIT)
+target'  = clamp(target', POW_CEILING, POW_LIMIT)
 ```
 
 where `TIMESPAN = 16 · 600` seconds (2 h 40 m). At all other heights, `bits` must
 equal the previous block's `bits`.
 
 **Deviation.** Bitcoin reads the first block of the *previous* window rather
-than the first block of the window being closed — an off-by-one present since
-2009 that makes each retarget cover 2015 intervals instead of 2016. ROFL uses
-the correct window. This is the one place ROFL knowingly diverges from
-Bitcoin's behaviour rather than its parameters.
+than the block immediately preceding the window being closed — an off-by-one present
+since 2009 that makes each retarget cover 2015 intervals instead of 2016. ROFL uses
+the full 16-interval window (`timestamp[h−1] − timestamp[h−17]`). Additionally, ROFL
+enforces a maximum difficulty ceiling `POW_CEILING = 0x1d03ffff` matching `k = 1024`,
+preventing difficulty from running away into unbounded territory when blocks are mined
+faster than the puzzle ceiling.
 
 ## 7. Subsidy
 

--- a/rofl/chain.py
+++ b/rofl/chain.py
@@ -15,6 +15,7 @@ from .consensus import (
     Block,
     ConsensusError,
     RETARGET_INTERVAL,
+    RETARGET_V2_HEIGHT,
     UTXOSet,
     bits_to_target,
     block_subsidy,
@@ -49,7 +50,7 @@ def append_block(block: Block, path: str = BLOCKS_FILE) -> None:
         fh.write(json.dumps(block.to_dict(), separators=(",", ":"), sort_keys=True) + "\n")
 
 
-def bits_for_height(height: int, blocks) -> int:
+def bits_for_height(height: int, blocks, v2_height: int = RETARGET_V2_HEIGHT) -> int:
     """
     The difficulty a block at `height` must use.
 
@@ -63,10 +64,23 @@ def bits_for_height(height: int, blocks) -> int:
     prev = blocks[height - 1]
     if height % RETARGET_INTERVAL != 0:
         return prev.bits
-    first_index = height - RETARGET_INTERVAL
-    if first_index < 0:
-        return prev.bits
-    return next_bits(height, prev.bits, blocks[first_index].timestamp, prev.timestamp)
+
+    if height >= v2_height:
+        # V2: True 16-block window from the block prior to the window (height - 17) to (height - 1).
+        first_index = max(0, height - RETARGET_INTERVAL - 1)
+    else:
+        # Legacy: Reads height - 16 (15 intervals).
+        first_index = height - RETARGET_INTERVAL
+        if first_index < 0:
+            return prev.bits
+
+    return next_bits(
+        height,
+        prev.bits,
+        blocks[first_index].timestamp,
+        prev.timestamp,
+        v2_height=v2_height,
+    )
 
 
 class ChainState:

--- a/rofl/consensus.py
+++ b/rofl/consensus.py
@@ -36,6 +36,12 @@ MAX_ADJUST_FACTOR = 4  # clamp, same as Bitcoin
 POW_LIMIT_BITS = 0x1E100000
 # Genesis difficulty (~2^24 hashes, roughly 30s of CPU mining).
 GENESIS_BITS = 0x1E010000
+# Hardest target the chain accepts (k = K_MAX = 1024 puzzles, ~2^30 hashes).
+# A ceiling stops runaway difficulty when blocks are solved faster than 10m.
+POW_CEILING_BITS = 0x1D03FFFF
+
+# Height at which difficulty adjustment v2 (true 16-block window and POW_CEILING_BITS) activates.
+RETARGET_V2_HEIGHT = 528
 
 COINBASE_MATURITY = 10  # blocks; Bitcoin uses 100
 MEDIAN_TIME_SPAN = 11  # blocks, same as Bitcoin
@@ -99,14 +105,18 @@ def difficulty(bits: int) -> float:
     return bits_to_target(POW_LIMIT_BITS) / bits_to_target(bits)
 
 
-def next_bits(height: int, prev_bits: int, first_ts: int, last_ts: int) -> int:
+def next_bits(
+    height: int,
+    prev_bits: int,
+    first_ts: int,
+    last_ts: int,
+    v2_height: int = RETARGET_V2_HEIGHT,
+) -> int:
     """
     Difficulty for the block at `height`.
 
     Retargets every RETARGET_INTERVAL blocks from the time actually taken by
     the previous window, clamped to a factor of 4 in either direction.
-    Unlike Bitcoin this reads the true first block of the window, without the
-    off-by-one that Bitcoin has carried since 2009.
     """
     if height % RETARGET_INTERVAL != 0 or height == 0:
         return prev_bits
@@ -119,6 +129,11 @@ def next_bits(height: int, prev_bits: int, first_ts: int, last_ts: int) -> int:
     new_target = bits_to_target(prev_bits) * actual // TARGET_TIMESPAN
     limit = bits_to_target(POW_LIMIT_BITS)
     new_target = min(new_target, limit)
+
+    if height >= v2_height:
+        ceiling = bits_to_target(POW_CEILING_BITS)
+        new_target = max(new_target, ceiling)
+
     return target_to_bits(new_target)
 
 

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -233,6 +233,32 @@ def run():
         lambda: chainmod.replay(good + [stale], now=now),
     )
 
+    # ---- v2 difficulty adjustment --------------------------------------
+    # 1. Test true 16-block window calculation without off-by-one
+    v2_blocks = list(good)
+    while len(v2_blocks) < 33:
+        v2_blocks.append(mine_block(v2_blocks, "ram0verflow", alice_addr))
+    expected_v2_bits = k.next_bits(
+        32,
+        v2_blocks[31].bits,
+        v2_blocks[15].timestamp,
+        v2_blocks[31].timestamp,
+        v2_height=32,
+    )
+    assert chainmod.bits_for_height(32, v2_blocks[:32], v2_height=32) == expected_v2_bits
+    ok("v2 difficulty retarget uses true 16-block window (anchor height 15)")
+
+    # 2. Test difficulty ceiling clamping to POW_CEILING_BITS
+    fast_bits = k.next_bits(
+        528,
+        0x17012b23,
+        1000,
+        1016,
+        v2_height=528,
+    )
+    assert fast_bits == k.POW_CEILING_BITS
+    ok(f"v2 difficulty retarget enforces ceiling POW_CEILING_BITS ({fast_bits:#010x})")
+
     # ---- final state ---------------------------------------------------
     final = chainmod.replay(good, now=now)
     print()


### PR DESCRIPTION
# Pull Request: Correct Difficulty Retarget Window and Enforce Proof-of-Work Ceiling

**Target Branch:** `main`  
**Topic Branch:** `fix/difficulty-adjustment-v2`  
**Related Specs:** [`SPEC.md` §2, §6](file:///e:/rofl/SPEC.md)

---

## Title
```
fix(consensus): correct retarget window interval and enforce difficulty ceiling at k=1024
```

---

## Overview

This pull request addresses two distinct issues in the ROFL difficulty retargeting implementation:

1. **The Retarget Window Off-by-One Interval:** Corrects the window interval calculation in [`rofl/chain.py`](file:///e:/rofl/rofl/chain.py) so that difficulty adjustment covers all 16 elapsed block intervals rather than 15, resolving the unintended omission of the boundary interval between retarget epochs.
2. **Proof-of-Work Difficulty Ceiling:** Introduces `POW_CEILING_BITS` (`0x1d03ffff`, corresponding to $k = K_{max} = 1024$, difficulty 1024.0) in [`rofl/consensus.py`](file:///e:/rofl/rofl/consensus.py) to prevent difficulty and target from drifting indefinitely into exponential scale while puzzle capacity is fixed at 1024.
3. **Consensus Backwards Compatibility:** Gates these improvements at `RETARGET_V2_HEIGHT = 528`, ensuring that historical blocks (0–527) in [`chain/blocks.jsonl`](file:///e:/rofl/chain/blocks.jsonl) continue to validate cleanly without breaking existing consensus.

---

## Problem Description & Root Cause Analysis

### 1. Retarget Window Interval Off-by-One

[`SPEC.md` §6](file:///e:/rofl/SPEC.md) notes an intent to avoid Bitcoin's historical off-by-one bug:
> *"Deviation. Bitcoin reads the first block of the previous window rather than the first block of the window being closed — an off-by-one present since 2009 that makes each retarget cover 2015 intervals instead of 2016. ROFL uses the correct window."*

However, the previous implementation in `rofl/chain.py` calculated the window using:
```python
first_index = height - RETARGET_INTERVAL  # e.g., 16 at height 32
actual = prev.timestamp - blocks[first_index].timestamp
```

Because block timestamps record the *completion* of mining, the difference `timestamp[31] - timestamp[16]` measures only the 15 block production intervals between block 16 and block 31:
$$\Delta t = \sum_{i=17}^{31} (t_i - t_{i-1}) = t_{31} - t_{16} \quad \text{(15 intervals)}$$

The interval required to produce block 16 (`timestamp[16] - timestamp[15]`) was omitted. Consequently, each window measured 15 intervals against a target timespan representing 16 intervals ($16 \times 600\text{ s} = 9600\text{ s}$), and the transition block between windows was never accounted for across the entire lifetime of the chain.

### 2. Runaway Difficulty Beyond the Puzzle Cap ($K_{max} = 1024$)

In [`rofl/pow.py`](file:///e:/rofl/rofl/pow.py), the number of subset-sum puzzles is capped at $K_{max} = 1024$:
```python
UNIT_WORK = 1 << 20
K_MAX = 1024

def k_for_work(work: int) -> int:
    return max(1, min(K_MAX, work // UNIT_WORK))
```

In [`rofl/consensus.py`](file:///e:/rofl/rofl/consensus.py), `next_bits` clamped only the lower difficulty bound (`POW_LIMIT_BITS`), with no upper bound (minimum target):
```python
new_target = bits_to_target(prev_bits) * actual // TARGET_TIMESPAN
limit = bits_to_target(POW_LIMIT_BITS)
new_target = min(new_target, limit)
```

When blocks are mined rapidly, target continually divides by up to $4\times$ each retarget. Once work exceeds $1024 \times 2^{20} = 2^{30}$ (target $\approx 2^{226}$, bits `0x1d03ffff`), $k$ remains capped at 1024. Any further difficulty increases do not increase block security or verification workload, yet target continues shrinking exponentially (reaching $\approx 10^{18}$ difficulty).

If miners subsequently disconnect, recovering to standard 10-minute blocks would require dozens of retarget epochs (hundreds of hours of stagnant chain state) due to the $4\times$ adjustment clamp per window.

---

## Proposed Changes

### Consensus Layer (`rofl/consensus.py` & `rofl/chain.py`)

1. **Difficulty Ceiling Constant:**
   Defined `POW_CEILING_BITS = 0x1D03FFFF`, which corresponds to target $2^{226}$ and exactly $k = 1024$ ($2^{30}$ expected work, difficulty $1024.0$ relative to `POW_LIMIT_BITS`).
2. **Ceiling Enforcement:**
   In `next_bits`, clamp `new_target` against the ceiling:
   ```python
   if height >= v2_height:
       ceiling = bits_to_target(POW_CEILING_BITS)
       new_target = max(new_target, ceiling)
   ```
3. **True 16-Block Window Anchor:**
   In `bits_for_height`, anchor the window start to the block preceding the window (`height - RETARGET_INTERVAL - 1`):
   ```python
   if height >= v2_height:
       first_index = max(0, height - RETARGET_INTERVAL - 1)
   else:
       first_index = height - RETARGET_INTERVAL
   ```
   For height 32, this spans `blocks[15].timestamp` to `blocks[31].timestamp`—precisely 16 continuous intervals ($31 - 15 = 16$).
4. **Activation Height:**
   Configured `RETARGET_V2_HEIGHT = 528` (the next upcoming retarget boundary) so that all prior blocks continue to evaluate under legacy rules.

### Specification (`SPEC.md`)

- Updated Table 2 (Chain parameters) to document `Proof-of-work ceiling = 0x1d03ffff (k = 1024)`.
- Updated Section 6 (Difficulty adjustment) to reflect `actual = timestamp[h−1] − timestamp[h−17]` and `target' = clamp(target', POW_CEILING, POW_LIMIT)`.

### Test Suite (`tests/test_chain.py`)

Added automated tests covering:
- Correctness of the true 16-interval anchor (`blocks[15]`) at height 32.
- Clamping of runaway difficulty targets to `POW_CEILING_BITS`.

---

## Verification & Test Results

### 1. Consensus Unit Test Suite
Ran `python tests/test_chain.py`:
```
ROFL consensus tests

  ok    genesis mined and self-consistent
  ok    12 blocks replay clean (height 11)
  ok    block containing a signed transaction accepted
  ok    bob holds 60.00005000 ROFL (10 received + reward + fee)
  ok    supply conserved: 650.00000000 ROFL emitted == unspent
  ok    immature coinbase cannot be spent
  ok    difficulty retargeted at height 16 (bits 0x1f00f000)
  ok    altered subset breaks proof of work
  ok    altered output breaks the merkle root
  ok    inflated coinbase rejected
  ok    forged signature rejected
  ok    stealing a block by renaming the miner invalidates the puzzles
  ok    padding the solution with an extra puzzle rejected
  ok    removing a block breaks the hash chain
  ok    mining at the wrong difficulty rejected
  ok    double spend of an already-spent output rejected
  ok    block built on a stale tip rejected
  ok    v2 difficulty retarget uses true 16-block window (anchor height 15)
  ok    v2 difficulty retarget enforces ceiling POW_CEILING_BITS (0x1d03ffff)

  19 checks passed
```

### 2. Historical Chain Replay
Replayed the entire sequence of historical blocks in `chain/blocks.jsonl` from height 0 to tip:
- **Result:** `520 blocks` replayed with `0` validation errors. Backwards compatibility is preserved.

---

## Checklist

- [x] Code adheres to the repository's existing style conventions.
- [x] All existing unit tests continue to pass.
- [x] New unit tests added covering the new logic paths.
- [x] Normative consensus documentation in `SPEC.md` updated to match the reference implementation.
- [x] No personal credentials, addresses, or local configurations included.
