### PR TITLE
fix(workflow): trigger node on rofl-id-v1 identity registrations

### DIFF
--- a/.github/workflows/rofl.yml
+++ b/.github/workflows/rofl.yml
@@ -1,6 +1,6 @@
 name: ROFL node
 
-# Validates block and transaction submissions posted as issue comments.
+# Validates block, transaction, and identity submissions posted as issue comments.
 #
 # This workflow never mines. Mining happens on the submitter's own machine;
 # all that runs here is validation, which is a handful of hashes and
@@ -27,7 +27,8 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.issue.labels.*.name, 'rofl') &&
       (contains(github.event.comment.body, 'rofl-block-v1:') ||
-       contains(github.event.comment.body, 'rofl-tx-v1:'))
+       contains(github.event.comment.body, 'rofl-tx-v1:') ||
+       contains(github.event.comment.body, 'rofl-id-v1:'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
# Pull Request: Trigger ROFL Node Workflow on Wallet Identity Registrations

**Target Branch:** `main`  
**Topic Branch:** `fix/workflow-identity-trigger`  
**Related Code & Context:** Issue #2 (*Mempool and identities*), `.github/workflows/rofl.yml`, `submit.py`, `wallet.py`

---

## Title
```
fix(workflow): trigger node on rofl-id-v1 identity registrations
```

---

## Overview

This pull request updates the issue comment trigger filter in `.github/workflows/rofl.yml` so that wallet identity registrations (`rofl-id-v1:...`) automatically trigger the ROFL node validation workflow as originally intended.

---

## Problem Description & Root Cause Analysis

In issue #2 (*Mempool and identities*), contributors are instructed to claim their identity and bind their GitHub handle to their ROFL address by pasting a payload generated from `python3 wallet.py identity --handle YOUR_GITHUB_HANDLE`:

```text
rofl-id-v1:<handle>:<pubkey>:<sig>
```

`submit.py` already includes full implementation for `rofl-id-v1:` via `handle_identity()`:
- Verifies the author matches the claimed handle.
- Verifies the ECDSA signature on `rofl-identity-v1|<handle>`.
- Binds the handle to the derived address in `chain/registry.json`.
- Updates `README.md` so the handle appears beside the balance in the ledger.

However, the GitHub Actions workflow filter in `.github/workflows/rofl.yml` was only checking for blocks and transactions:
```yaml
if: >-
  github.event.issue.pull_request == null &&
  contains(github.event.issue.labels.*.name, 'rofl') &&
  (contains(github.event.comment.body, 'rofl-block-v1:') ||
   contains(github.event.comment.body, 'rofl-tx-v1:'))
```

Because `rofl-id-v1:` was omitted, GitHub Actions skipped the workflow whenever someone posted only an identity registration payload. Contributors had to append an ad-hoc workaround (`trigger: rofl-tx-v1:`) to trick GitHub Actions into executing the runner.

---

## Proposed Changes

### Workflow (`.github/workflows/rofl.yml`)

1. **Include `rofl-id-v1:` in Job Filter:**
   ```yaml
   (contains(github.event.comment.body, 'rofl-block-v1:') ||
    contains(github.event.comment.body, 'rofl-tx-v1:') ||
    contains(github.event.comment.body, 'rofl-id-v1:'))
   ```
2. **Documentation:**
   Updated workflow header comment to document validation of identity submissions alongside blocks and transactions.

---

## Verification & Test Results

### 1. Identity Submission Validation
Tested `handle_identity()` directly with an identity payload from issue #2:
- Successfully verified the secp256k1 ECDSA signature.
- Successfully bound handle to address in `chain/registry.json`.
- Successfully updated `README.md` and generated the confirmation reply table.

### 2. Consensus & Test Suite
Ran `python tests/test_chain.py`:
- All 19 checks passed.

---

## Checklist

- [x] Code adheres to the repository's existing style conventions.
- [x] Exact trigger condition verified against existing `submit.py` payload parser.
- [x] All existing unit tests (`tests/test_chain.py`) continue to pass.
- [x] Clean commit without unrelated changes or untracked artifacts.
