### PR TITLE
Keep a writable ROFL submission issue available

### DIFF
--- a/.github/workflows/rofl-intake.yml
+++ b/.github/workflows/rofl-intake.yml
@@ -1,0 +1,35 @@
+name: ROFL submission intake
+
+# GitHub disables comments once an issue reaches 2500 comments. Keep a fresh
+# labelled issue available before the current one reaches that hard limit.
+on:
+  schedule:
+    - cron: '0,10,20,30,40,50 * * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ensure_submission_issue.py
+      - .github/workflows/rofl-intake.yml
+
+concurrency:
+  group: rofl-intake
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  ensure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Ensure a writable submission issue exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 ensure_submission_issue.py

--- a/.github/workflows/rofl.yml
+++ b/.github/workflows/rofl.yml
@@ -81,3 +81,22 @@ jobs:
         run: |
           printf '%s\n' "$REPLY" > /tmp/reply.md
           gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/reply.md
+
+  intake:
+    name: Keep a writable submission issue available
+    if: always()
+    needs: submit
+    concurrency:
+      group: rofl-intake
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Check submission issue capacity
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 ensure_submission_issue.py

--- a/.github/workflows/rofl.yml
+++ b/.github/workflows/rofl.yml
@@ -84,7 +84,10 @@ jobs:
 
   intake:
     name: Keep a writable submission issue available
-    if: always()
+    if: >-
+      always() &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'rofl')
     needs: submit
     concurrency:
       group: rofl-intake

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,5 +19,7 @@ jobs:
           python-version: '3.11'
       - name: Consensus tests
         run: python3 tests/test_chain.py
+      - name: Submission intake tests
+        run: python3 tests/test_intake.py
       - name: Replay the chain from genesis
         run: python3 verify.py

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 <p align="center">
   <a href="https://ram0verflow.github.io/ram0verflow/"><b>Block explorer</b></a> ·
   <a href="SPEC.md"><b>Consensus spec</b></a> ·
-  <a href="../../issues/1"><b>Mine a block</b></a> ·
-  <a href="../../issues/2"><b>Send coins</b></a> ·
+  <a href="../../issues?q=is%3Aissue%20is%3Aopen%20label%3Arofl-active"><b>Mine a block</b></a> ·
+  <a href="../../issues?q=is%3Aissue%20is%3Aopen%20label%3Arofl-active"><b>Send coins</b></a> ·
   <a href="../../actions"><b>Node</b></a>
 </p>
 
@@ -134,7 +134,8 @@ python3 miner.py --miner YOUR_GITHUB_HANDLE --message "gm"
 
 It solves puzzles until the block is complete, then prints a line starting
 with `rofl-block-v1:`. Paste that as a comment on
-**[the block issue](../../issues/1)**. A workflow validates it and, if it
+**[the active submission issue](../../issues?q=is%3Aissue%20is%3Aopen%20label%3Arofl-active)**.
+A workflow validates it and, if it
 holds up, appends it to the chain and updates this page.
 
 About half a minute at the starting difficulty. If the chain gets busy,
@@ -158,7 +159,7 @@ cannot be altered or stripped on the way, and it shows up in the ledger above.
 
 Two ways to submit it, and they do the same thing:
 
-- **Comment** on **[the mempool issue](../../issues/2)**. Ten seconds.
+- **Comment** on **[the active submission issue](../../issues?q=is%3Aissue%20is%3Aopen%20label%3Arofl-active)**. Ten seconds.
 - **Pull request** adding one file under `chain/pending/`, if you want the
   contribution on your profile. The node reads the file, applies the
   transaction to `main` and closes the PR — it is never merged, so your
@@ -173,7 +174,7 @@ picked first, and the fee goes to whoever mines the block.
 python3 wallet.py identity --handle YOUR_GITHUB_HANDLE
 ```
 
-Post the `rofl-id-v1:` line it prints on **[the mempool issue](../../issues/2)**
+Post the `rofl-id-v1:` line it prints on **[the active submission issue](../../issues?q=is%3Aissue%20is%3Aopen%20label%3Arofl-active)**
 from the account it names. The signature proves you hold the key; posting it
 from your account proves you hold the handle. Your name then appears beside
 your balance in the table above.

--- a/SETUP.md
+++ b/SETUP.md
@@ -48,23 +48,27 @@ git remote add origin https://github.com/ram0verflow/ram0verflow.git
 git push -u origin main
 ```
 
-## 4. Open the two issues
+## 4. Open the first two submission issues
 
 Both need the label `rofl` — the workflow ignores comments anywhere else.
 
 ```bash
 gh label create rofl --description "ROFL chain submissions" --color 8A5F10
+gh label create rofl-active --description "Current writable ROFL submission issue" --color 2DA44E
 
-gh issue create --title "Mine a block" --label rofl --body \
-"Paste your \`rofl-block-v1:\` line as a comment. See the README to mine one."
+block_issue=$(gh issue create --title "Mine a block" --label rofl --body \
+"Paste your \`rofl-block-v1:\` line as a comment. See the README to mine one.")
 
 gh issue create --title "Mempool" --label rofl --body \
 "Paste your \`rofl-tx-v1:\` line as a comment to queue a transaction."
+
+gh issue edit "$block_issue" --add-label rofl-active
 ```
 
-These must end up as issues **#1** (blocks) and **#2** (mempool) for the
-README links to point at the right places. If they land on different numbers,
-edit the two links at the top of README.md.
+The active label is the stable target used by the README links. A maintenance
+workflow moves it to a fresh issue once the current one reaches 2200 comments,
+before GitHub disables comments at 2500. The second issue is the first standby;
+after that, the workflow creates new submission issues automatically.
 
 Pin both from the issue page so visitors find them.
 

--- a/ensure_submission_issue.py
+++ b/ensure_submission_issue.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Keep a writable, discoverable ROFL submission issue available."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Optional
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+COMMENT_LIMIT = 2500
+ROLLOVER_AT = 2200
+SUBMISSION_LABEL = "rofl"
+ACTIVE_LABEL = "rofl-active"
+
+
+class GitHubAPIError(RuntimeError):
+    def __init__(self, status: int, detail: str):
+        self.status = status
+        super().__init__(f"GitHub API {status}: {detail}")
+
+
+def api_request(token: str, repo: str, path: str, *, method="GET", body=None):
+    data = None if body is None else json.dumps(body).encode()
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "rofl-submission-intake",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+            return json.loads(payload) if payload else None
+    except urllib.error.HTTPError as exc:
+        payload = exc.read().decode(errors="replace")
+        try:
+            detail = json.loads(payload).get("message", payload)
+        except json.JSONDecodeError:
+            detail = payload
+        raise GitHubAPIError(exc.code, detail) from exc
+
+
+def label_names(issue: dict) -> set[str]:
+    return {
+        label["name"] if isinstance(label, dict) else str(label)
+        for label in issue.get("labels", [])
+    }
+
+
+def choose_submission_issue(
+    issues: list[dict], rollover_at: int
+) -> Optional[dict]:
+    """Prefer a healthy active issue, then the newest healthy standby."""
+    issues = [
+        issue
+        for issue in issues
+        if "pull_request" not in issue
+        and issue.get("state") == "open"
+        and issue.get("comments", 0) < rollover_at
+    ]
+    active = [issue for issue in issues if ACTIVE_LABEL in label_names(issue)]
+    pool = active or issues
+    return max(pool, key=lambda issue: issue["number"], default=None)
+
+
+def ensure_label(token: str, repo: str, name: str, color: str, description: str):
+    encoded = urllib.parse.quote(name, safe="")
+    try:
+        api_request(token, repo, f"/labels/{encoded}")
+    except GitHubAPIError as exc:
+        if exc.status != 404:
+            raise
+        api_request(
+            token,
+            repo,
+            "/labels",
+            method="POST",
+            body={"name": name, "color": color, "description": description},
+        )
+
+
+def create_submission_issue(token: str, repo: str) -> dict:
+    return api_request(
+        token,
+        repo,
+        "/issues",
+        method="POST",
+        body={
+            "title": "ROFL submissions",
+            "body": (
+                "Post `rofl-block-v1:` block candidates or `rofl-tx-v1:` "
+                "transactions here. This issue was opened automatically before "
+                "the previous submission issue reached GitHub's comment limit."
+            ),
+            "labels": [SUBMISSION_LABEL, ACTIVE_LABEL],
+        },
+    )
+
+
+def set_active_issue(token: str, repo: str, issues: list[dict], target: dict):
+    target_number = target["number"]
+    if ACTIVE_LABEL not in label_names(target):
+        api_request(
+            token,
+            repo,
+            f"/issues/{target_number}/labels",
+            method="POST",
+            body={"labels": [ACTIVE_LABEL]},
+        )
+
+    encoded = urllib.parse.quote(ACTIVE_LABEL, safe="")
+    for issue in issues:
+        if issue["number"] == target_number or ACTIVE_LABEL not in label_names(issue):
+            continue
+        try:
+            api_request(
+                token,
+                repo,
+                f"/issues/{issue['number']}/labels/{encoded}",
+                method="DELETE",
+            )
+        except GitHubAPIError as exc:
+            # A concurrent run may already have removed it.
+            if exc.status != 404:
+                raise
+
+
+def write_outputs(issue: dict, created: bool):
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as output:
+        output.write(f"issue_number={issue['number']}\n")
+        output.write(f"issue_url={issue['html_url']}\n")
+        output.write(f"created={str(created).lower()}\n")
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("GITHUB_TOKEN and GITHUB_REPOSITORY are required", file=sys.stderr)
+        return 2
+
+    rollover_at = int(os.environ.get("ROFL_ISSUE_ROLLOVER_AT", ROLLOVER_AT))
+    if not 1 <= rollover_at < COMMENT_LIMIT:
+        raise ValueError(
+            f"ROFL_ISSUE_ROLLOVER_AT must be between 1 and {COMMENT_LIMIT - 1}"
+        )
+
+    ensure_label(token, repo, SUBMISSION_LABEL, "8A5F10", "ROFL submissions")
+    ensure_label(
+        token,
+        repo,
+        ACTIVE_LABEL,
+        "2DA44E",
+        "Current writable ROFL submission issue",
+    )
+    issues = api_request(
+        token,
+        repo,
+        f"/issues?state=open&labels={SUBMISSION_LABEL}&per_page=100",
+    )
+    target = choose_submission_issue(issues, rollover_at)
+    created = target is None
+    if created:
+        target = create_submission_issue(token, repo)
+        issues.append(target)
+    set_active_issue(token, repo, issues, target)
+    write_outputs(target, created)
+    action = "Created" if created else "Using"
+    print(
+        f"{action} submission issue #{target['number']} "
+        f"({target.get('comments', 0)}/{COMMENT_LIMIT} comments): "
+        f"{target['html_url']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Tests for submission-issue rollover selection."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ensure_submission_issue import ACTIVE_LABEL, choose_submission_issue
+
+
+def issue(number, comments, *, active=False, state="open", pull_request=False):
+    result = {
+        "number": number,
+        "comments": comments,
+        "state": state,
+        "labels": ([{"name": ACTIVE_LABEL}] if active else []),
+    }
+    if pull_request:
+        result["pull_request"] = {"url": "https://example.invalid/pr"}
+    return result
+
+
+def main():
+    assert choose_submission_issue([issue(1, 10, active=True)], 2200)["number"] == 1
+
+    # Rotate away from an active issue before GitHub's 2500-comment hard limit.
+    issues = [issue(1, 2200, active=True), issue(2, 7)]
+    assert choose_submission_issue(issues, 2200)["number"] == 2
+
+    # Prefer the newest standby when recovering a repository with no active label.
+    issues = [issue(1, 2500), issue(2, 100), issue(4, 100)]
+    assert choose_submission_issue(issues, 2200)["number"] == 4
+
+    # Closed issues and pull requests are never submission targets.
+    issues = [issue(3, 0, state="closed"), issue(4, 0, pull_request=True)]
+    assert choose_submission_issue(issues, 2200) is None
+
+    # Once every issue is near capacity the caller must create a fresh one.
+    assert choose_submission_issue([issue(1, 2200), issue(2, 2500)], 2200) is None
+
+    print("5 intake rollover checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- rotate the active ROFL submission issue at 2,200 comments, before GitHub disables commenting at 2,500
- recover automatically when every labelled issue is already full
- add a stable `rofl-active` label and use it for README submission links instead of hard-coded issue numbers
- check capacity after node runs and every ten minutes
- add deterministic tests for active/standby/full issue selection

## Why

Both current submission issues have reached 2,500 comments. GitHub now returns `403: Commenting is disabled on issues with more than 2500 comments`, leaving the chain without a normal writable intake. Keeping old `rofl` labels preserves compatibility with clients still targeting an existing issue; the new label only identifies the issue linked from the README.

The maintenance script runs from the base repository and only uses the scoped `GITHUB_TOKEN` to manage labels and issues. A separate concurrency group prevents duplicate rollover jobs.

## Verification

- `python3 tests/test_intake.py`
- `python3 tests/test_chain.py`
- `python3 verify.py` (817 blocks through height 816)
- `actionlint`
- live read-only dry run correctly found no writable issue among #1 and #2
