### PR TITLE
perf(ci): remove duplicate chain verification

### DIFF
--- a/.github/workflows/rofl-pr.yml
+++ b/.github/workflows/rofl-pr.yml
@@ -132,8 +132,6 @@ jobs:
               finish 0
             fi
 
-            python3 verify.py || finish 1
-
             git add chain/ README.md assets/ 2>/dev/null || true
             if git diff --cached --quiet; then finish 0; fi
             git commit -m "rofl: submission from @$COMMENT_AUTHOR (#$PR)"


### PR DESCRIPTION
## Summary
- Remove the redundant full-chain erify.py pass from the pull-request submission relay.
- Keep submit.py as the validation gate; it already replays the current chain and validates the candidate before applying it.
- Preserve the existing fetch/reset/revalidate loop for concurrent submissions.

This avoids spending roughly 1-2 minutes replaying the chain a second time before the push race window.

## Verification
- Parsed .github/workflows/rofl-pr.yml successfully with PyYAML.
- git diff --check passes.